### PR TITLE
Add Support for sending/recieving file-descriptors in the core messenger

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://stardustxr.org"
 cluFlock = "1.2.7"
 color-rs = "0.7.1"
 mint = { version = "0.5.9", features = ["serde"] }
+nix = "0.26.2"
 parking_lot = "0.12.1"
 stardust-xr-schemas = { path = "../schemas", version = "1.5.0" }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/core/src/scenegraph.rs
+++ b/core/src/scenegraph.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use std::os::unix::io::RawFd;
 
 /// Error for all scenegraph-related things.
 #[derive(Error, Debug)]
@@ -19,13 +20,14 @@ pub enum ScenegraphError {
 
 /// Handles node signals and method calls for the messenger.
 pub trait Scenegraph {
-	fn send_signal(&self, path: &str, method: &str, data: &[u8]) -> Result<(), ScenegraphError> {
-		self.execute_method(path, method, data).map(|_| ())
+	fn send_signal(&self, path: &str, method: &str, data: &[u8], fds: Vec<RawFd>) -> Result<(), ScenegraphError> {
+		self.execute_method(path, method, data, fds).map(|_| ())
 	}
 	fn execute_method(
 		&self,
 		path: &str,
 		method: &str,
 		data: &[u8],
+		fds: Vec<RawFd>,
 	) -> Result<Vec<u8>, ScenegraphError>;
 }

--- a/fusion/src/drawable/mod.rs
+++ b/fusion/src/drawable/mod.rs
@@ -45,6 +45,7 @@ fn set_sky(
 			"/drawable",
 			"set_sky_file",
 			&serialize(&(file_str, tex, light)).map_err(|_| NodeError::Serialization)?,
+			&[],
 		)
 		.map_err(|e| NodeError::MessengerError { e })
 }

--- a/fusion/src/items/mod.rs
+++ b/fusion/src/items/mod.rs
@@ -150,6 +150,7 @@ impl<I: Item> ItemUI<I> {
 				"/item",
 				"register_item_ui",
 				&serialize([I::TYPE_NAME]).map_err(|_| NodeError::Serialization)?,
+				&[],
 			)
 			.map_err(|e| NodeError::MessengerError { e })?;
 		Ok(item_ui)

--- a/fusion/src/node.rs
+++ b/fusion/src/node.rs
@@ -101,7 +101,7 @@ impl Drop for NodeInternals {
 		if let Some(client) = self.client.upgrade() {
 			let path = self.path();
 			if self.destroyable {
-				let _ = client.message_sender_handle.signal(&path, "destroy", &[]);
+				let _ = client.message_sender_handle.signal(&path, "destroy", &[], &[]);
 			}
 			client.scenegraph.remove_node(&path);
 		}
@@ -131,6 +131,7 @@ impl Node {
 				interface_path,
 				interface_method,
 				&serialize(data).map_err(|_| NodeError::Serialization)?,
+				&[],
 			)
 			.map_err(|e| NodeError::MessengerError { e })?;
 
@@ -226,7 +227,7 @@ impl Node {
 	pub fn send_remote_signal_raw(&self, signal_name: &str, data: &[u8]) -> Result<(), NodeError> {
 		self.client()?
 			.message_sender_handle
-			.signal(&self.get_path()?, signal_name, data)
+			.signal(&self.get_path()?, signal_name, data, &[])
 			.map_err(|e| NodeError::MessengerError { e })
 	}
 	/// Execute a method on the node on the server. Not needed unless implementing functionality Fusion does not already have.
@@ -266,7 +267,7 @@ impl Node {
 		let future = self
 			.client()?
 			.message_sender_handle
-			.method(&self.get_path()?, method_name, data)
+			.method(&self.get_path()?, method_name, data, &[])
 			.map_err(|e| NodeError::MessengerError { e })?;
 
 		Ok(async move { future.await.map_err(|e| NodeError::ReturnedError { e }) })


### PR DESCRIPTION
I was not able to use sendFd because it didn't do async, but I was able to learn from it's source how it worked with Tokio and was able to do that myself as well
Originally, I had planned to include the FDs when the header is sent, but moved it to the body so that the number of FDs could be sent in the header too 
the number to receive is limited by the OS; modern Linux is limited to 253 FDS
withFd just always made the buffer for receiving the FDs big enough to receive all 253, so I could have done it that way instead and used the suggested cmsg_space macro (I had to reimplement it to accept a variable number of expected FDs, but it was only a few lines) 
I brought the FDs all the way up to the scenegraph and mostly stopped there, thinking you'll want to take over from there. 

I also recommend turning the method response return value into a tuple (Vec<u8>, Vec<RawFd>)

Also: You have to send some data in the body if you're sending an FD. If that doesn't work for you, we can switch it back to the header message and fixed 253, since the header always has something.

I did not test it at all, but it did compile.