### PR TITLE
fix(core): remove redundant dep `chrono`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,6 +26,5 @@ tokio = { version = "1.29.1", features = [
     "rt",
     "parking_lot",
 ] }
-chrono = "0.4.26"
 tracing = "0.1.37"
 dirs = "5.0.1"


### PR DESCRIPTION
Dependency `chrono` is not used - and it pulls legacy `time` 0.1 with `oldtime` where as newtime is RiR localtime

$ cargo tree -i time
```
time v0.1.45
└── chrono v0.4.26
    └── stardust-xr v0.13.0 (/home/foobar/code/stardust/core/core)
        └── stardust-xr-fusion v0.42.1 (/home/foobar/code/stardust/core/fusion)
```

Just an annoyance that jumped into my eyes couldn't resist :)